### PR TITLE
Changes to definitions of <testsuite> and <testcase> in JUnit reports

### DIFF
--- a/lib/runner/reporters/junit.js
+++ b/lib/runner/reporters/junit.js
@@ -25,14 +25,15 @@ module.exports = new (function() {
 
   function writeReport(moduleKey, data, opts, callback) {
     var module = globalResults.modules[moduleKey];
-    var tests = 0, errors = 0, failures = 0;
+    var assertions = 0, tests = 0, errors = 0, failures = 0;
     var pathParts = moduleKey.split(path.sep);
     var moduleName = pathParts.pop();
     var output_folder = opts.output_folder;
 
     for (var x in module) {
       if (module.hasOwnProperty(x)) {
-        tests += module[x].passed + module[x].failed + module[x].skipped;
+        assertions += module[x].passed + module[x].failed + module[x].skipped;
+        tests += 1;
         errors += module[x].errors;
         failures += module[x].failed;
       }

--- a/lib/runner/reporters/junit.xml.ejs
+++ b/lib/runner/reporters/junit.xml.ejs
@@ -1,32 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="<%= moduleName %>"
-             errors="<%= errors %>"
-             failures="<%= failures %>"
-             tests="<%= testsNo %>">
-  <% for (var testsuite in module) { %>
-  <testsuite errors="<%= module[testsuite].errors %>" failures="<%= module[testsuite].failed %>" hostname="" id=""
-    name="<%= testsuite %>" package="<%= moduleName %>" skipped="<%= module[testsuite].skipped %>"
-    tests="<%= (module[testsuite].tests.length + module[testsuite].skipped) %>" time="" timestamp="">
-    <% var tests = module[testsuite].tests %>
-    <% for (var i = 0; i < tests.length; i++) { %>
-      <testcase name="<%= tests[i].message %>">
-        <% if (tests[i].failure) { %>
-          <failure message="<%= tests[i].failure %>"></failure>
-        <% } %>
-        <% if (tests[i].screenshots && tests[i].screenshots.length > 0) { %>
-          <system-out>
+<testsuite name="<%= moduleName %>"
+           errors="<%= errors %>"
+           failures="<%= failures %>"
+           tests="<%= testsNo %>">
+    <% for (var testcase in module) { %>
+    <testcase errors="<%= module[testcase].errors %>" failures="<%= module[testcase].failed %>" hostname="" id=""
+              name="<%= testcase %>" skipped="<%= module[testcase].skipped %>"
+              assertions="<%= (module[testcase].tests.length + module[testcase].skipped) %>" time="" timestamp="">
+        <%  var tests = module[testcase].tests
+        for (var i = 0; i < tests.length; i++) {
+        if (tests[i].failure) { %>
+        <failure message="<%= tests[i].failure %>">
+            <% for (var j = 0; j < i; j++) { -%>
+            <%=  tests[j].message %>
+            <% } -%>
+
+            <%= tests[i].stacktrace %>
+        </failure>
+        <%} if (tests[i].screenshots && tests[i].screenshots.length > 0) { %>
+        <system-out>
             <% for (var j = 0; j < tests[i].screenshots.length; j++) { %>
-              [[ATTACHMENT|<%= tests[i].screenshots[j] %>]]
+            [[ATTACHMENT|<%= tests[i].screenshots[j] %>]]
             <% } %>
-          </system-out>
-        <% } %>
-      </testcase>
-    <% } %>
-    <% if (systemerr != '') {%>
-      <system-err>
+        </system-out>
+        <%}} %>
+    </testcase>
+    <% } if (systemerr !== '') {%>
+    <system-err>
         <%= systemerr %>
-      </system-err>
+    </system-err>
     <% } %>
-    </testsuite>
-  <% } %>
-</testsuites>
+</testsuite>


### PR DESCRIPTION
having the same problems as in:
https://github.com/beatfactor/nightwatch/issues/191

namely:
Treating each assertion as a testcase leads to 1) overflow of information in results, 2) CI systems not being able to track tests history properly

I suggest:
a single test file to be treated as a testsuite (java TestClass analogue), while testcase is a Test Method analogue. As each report contains only 1 testsuite, "testsuites" node can be omitted. 
<testcase> contains a number of performed assertions in the corresponding attribute.
In case of failure, a sequence of assertions up to the failed one is printed along with the stacktrace.

