### PR TITLE
Give module as context for global reporter

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -586,7 +586,7 @@ module.exports = new (function() {
               }
 
               if (additional_opts.output_folder === false) {
-                globalReporter.call(opts.globals, globalResults, function() {
+                globalReporter.call(module, globalResults, function() {
                   finishCallback(null, globalResults, modulekeys);
                 });
               } else {
@@ -608,7 +608,7 @@ module.exports = new (function() {
                       console.log(err.stack);
                     }
 
-                    globalReporter.call(opts.globals, globalResults, function() {
+                    globalReporter.call(module, globalResults, function() {
                       finishCallback(null, globalResults);
                     });
                   });


### PR DESCRIPTION
I'm using global reporter to send test result to Sauce Labs. I think that's the best place to keep the reporting code. Only problem is that Sauce Labs requires sessionId and that's not currently available. I solved the problem by giving `module` as context to reporter like for tearDown.

Was there a reason to expose just globals? This would be a backwards incompatible change (unless globals are aliased to the root level) so I just leave this PR here and let you decide.

@beatfactor @mildmojo 