### PR TITLE
always log selenium server errors

### DIFF
--- a/lib/runner/selenium.js
+++ b/lib/runner/selenium.js
@@ -99,8 +99,8 @@ SeleniumServer.prototype.onError = function(err) {
   if (err.code == 'ENOENT') {
     console.log(Logger.colors.red('\nAn error occurred while trying to start Selenium. ' +
       'Check if JAVA is installed on your machine.'));
-    console.log(util.inspect(err, false, 1, true));
   }
+    console.log(util.inspect(err, false, 1, true));
 };
 
 SeleniumServer.prototype.onStderrData = function(data) {


### PR DESCRIPTION
with a fairly large nightwatch based deploy, we have had a number of issues
with various setups that crash when attempting to launch selenium. This change
has helped find a number of strange problems.