### PR TITLE
Allow for absolute path to custom command path

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -3,6 +3,7 @@
  */
 var fs = require('fs');
 var path = require('path');
+var pathIsAbsolute = require('path-is-absolute');
 var util = require('util');
 var events = require('events');
 var assertModule = require('assert');
@@ -250,7 +251,7 @@ module.exports = new (function() {
       return;
     }
 
-    var absPath = path.join(process.cwd(), dirPath);
+    var absPath = pathIsAbsolute(dirPath) ? dirPath : path.join(process.cwd(), dirPath);
     var commandFiles = fs.readdirSync(absPath);
 
     commandFiles.forEach(function(file) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "ejs": "~0.8.3",
     "optimist": ">=0.3.5",
     "minimatch": "~0.2.14",
-    "mkpath": ">=0.1.0"
+    "mkpath": ">=0.1.0",
+    "path-is-absolute": ">=1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.4",

--- a/tests/src/testNightwatchApi.js
+++ b/tests/src/testNightwatchApi.js
@@ -1,5 +1,6 @@
 var BASE_PATH = process.env.NIGHTWATCH_COV ? 'lib-cov' : 'lib';
 
+var path = require('path');
 var Api = require('../../' + BASE_PATH + '/core/api.js');
 
 module.exports = {
@@ -57,6 +58,25 @@ module.exports = {
     var command = queue.currentNode;
     test.equal(command.name, 'customCommandConstructor');
     test.equal(command.context, client.api, 'Command should contain a reference to main client instance.');
+  },
+
+  testAddCustomCommandFullPath : function(test) {
+    var client = this.client;
+    client.on('selenium:session_create', function(sessionId) {
+      test.done();
+    });
+
+    var absPath = path.join(process.cwd(), 'extra/commands');
+    client.options.custom_commands_path = [absPath];
+    Api.init(client);
+
+    test.doesNotThrow(
+      function() {
+        Api.loadCustomCommands();
+      }, Error, 'Exception thrown loading custom command with absolute path'
+    );
+
+    test.ok('customCommand' in this.client.api, 'Commands defined with an absolute path were not loaded properly');
   },
 
 


### PR DESCRIPTION
Allow for the user to specify an absolute path to their custom_command_path.