### PR TITLE
Make page objects work with more than 1 test file

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -335,10 +335,7 @@ module.exports = new (function() {
 
       return new (function() {
         if (typeof pageFnOrObject == 'function') {
-          if (!pageFnOrObject.prototype._instance) {
-            pageFnOrObject.prototype._instance = createPageObject(pageFnOrObject, args);
-          }
-          return pageFnOrObject.prototype._instance;
+          return createPageObject(pageFnOrObject, args);
         }
 
         return pageFnOrObject;


### PR DESCRIPTION
There might be a better solution, but this at least ensures the right client gets passed to the page object.

What happenede before was that the page object was stuck with the first client passed in.