### PR TITLE
Fix pause(0) suspending indefinitely

### DIFF
--- a/lib/api/commands/pause.js
+++ b/lib/api/commands/pause.js
@@ -28,7 +28,7 @@ Pause.prototype.command = function(ms, cb) {
   var self = this;
   // If we don't pass the milliseconds, the client will
   // be suspended indefinitely
-  if (!ms) {
+  if (typeof ms === 'undefined') {
     return this;
   }
   setTimeout(function() {


### PR DESCRIPTION
Hi!

I found that `pause(0)` suspend a test indefinitely.
This PR fixes this issue.