### PR TITLE
Close http connections

### DIFF
--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -50,7 +50,8 @@ module.exports = (function() {
       host    : options.host || Settings.selenium_host,
       port    : options.selenium_port || Settings.selenium_port,
       method  : options.method || 'POST',
-      headers : {}
+      headers : {},
+      agent   : false
     };
     var requestMethod = reqOptions.method.toUpperCase();
     if (options.sessionId) {


### PR DESCRIPTION
As discussed in #401 and #398 HTTP header got `Connection:'keep-alive'` value, because agent not specified. As said @beatfactor by default `keepAlive: false`, but if agent not specified using agent default value (`undefined`) and `keepAlive: true`, as write [node http request module doc](https://nodejs.org/api/http.html#http_http_request_options_callback). As result got useless opened connections.
