### PR TITLE
Add option to retry failed assertions

### DIFF
--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -99,8 +99,8 @@ module.exports = new (function() {
         return self._reschedule();
       }
 
-      var expected = typeof self.expected == 'function' ? self.expected() : self.expected,
-          message = self._getFullMessage(passed, timeSpent);
+      var expected = typeof self.expected == 'function' ? self.expected() : self.expected;
+      var message = self._getFullMessage(passed, timeSpent);
 
       self.client.assertion(passed, value, expected, message, self.abortOnFailure);
       self.emit('complete');

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -37,9 +37,9 @@ module.exports = new (function() {
     this.api = client.api;
     this.startTime = new Date().getTime();
     this.globals = this.api.globals || {};
-    this.timeout = this.globals.assertWaitForConditionTimeout || 0; //ms
+    this.timeout = this.globals.retryAssertionTimeout || 0; //ms
     this.rescheduleInterval = this.globals.waitForConditionPollInterval || 500; //ms
-    this.shouldWait = this.timeout > 0;
+    this.shouldRetry = this.timeout > 0;
   }
 
   util.inherits(BaseAssertion, events.EventEmitter);
@@ -108,7 +108,7 @@ module.exports = new (function() {
   };
 
   BaseAssertion.prototype._getFullMessage = function(passed, timeSpent) {
-    if ( !this.shouldWait) {
+    if ( !this.shouldRetry) {
       return this.message;
     }
     var timeLogged = passed? timeSpent : this.timeout;

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -35,6 +35,10 @@ module.exports = new (function() {
     this.abortOnFailure = abortOnFailure;
     this.client = client;
     this.api = client.api;
+    this.startTime= new Date().getTime();
+    this.timeout = this.client.api.globals.assertWaitForConditionTimeout || 0;
+    this.shouldWait = this.timeout > 0;
+    this.rescheduleInterval = this.client.api.globals.waitForConditionPollInterval || 500;
   }
 
   util.inherits(BaseAssertion, events.EventEmitter);
@@ -53,6 +57,7 @@ module.exports = new (function() {
    * @returns {*}
    * @private
    */
+
   BaseAssertion.prototype._executeCommand = function() {
     var self = this;
     var methods = [
@@ -68,17 +73,18 @@ module.exports = new (function() {
         if (typeof self[name] !== 'function') {
           throw new Error('Assertion must implement method ' + name);
         }
+
       } else if (typeof self[method] == 'undefined') {
         throw new Error('Assertion must implement method/property ' + method);
       }
     });
 
-    var startTime= new Date().getTime(),
-        timeout = self.client.api.globals.assertWaitForConditionTimeout || 0,
-        rescheduleInterval = self.client.api.globals.waitForConditionPollInterval || 500,
-        shouldWait = timeout != 0;
+    return this._scheduleAssertion();
+  };
 
-    var processResult = function(result) {
+  BaseAssertion.prototype._scheduleAssertion = function() {
+    var self = this;
+    return this.command(function(result) {
       var passed, value;
 
       if (typeof self.failure == 'function' && self.failure(result)) {
@@ -89,22 +95,30 @@ module.exports = new (function() {
         passed = self.pass(value);
       }
 
-      var expected = typeof self.expected == 'function' ? self.expected() : self.expected,
-          timeSpent = new Date().getTime() - startTime,
-          addlMessage = shouldWait ? self.message + ' after ' + timeSpent + ' milliseconds.' : '',
-          message = self.message + addlMessage;
-
-      if (shouldWait && !passed && timeSpent < timeout) {
-        var that = self;
-        return setTimeout(function() {
-          that.command(processResult);
-        }, rescheduleInterval)
+      var timeSpent = new Date().getTime() - self.startTime;
+      if (!passed && timeSpent < self.timeout) {
+        return self._reschedule();
       }
+
+      var expected = typeof self.expected == 'function' ? self.expected() : self.expected,
+          message = self._getFullMessage(passed, timeSpent);
 
       self.client.assertion(passed, value, expected, message, self.abortOnFailure);
       self.emit('complete');
-    };
-    return this.command(processResult);
+    });
+  };
+
+  BaseAssertion.prototype._getFullMessage = function(passed, timeSpent) {
+    if ( !this.shouldWait) {
+      return this.message;
+    }
+    var timeLogged = passed? timeSpent : this.timeout;
+    return this.message +  ' after ' + timeLogged + ' milliseconds.';
+  };
+
+  BaseAssertion.prototype._reschedule = function() {
+    setTimeout(function(){}, this.rescheduleInterval);
+    return this._scheduleAssertion();
   };
 
   /**

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -35,7 +35,7 @@ module.exports = new (function() {
     this.abortOnFailure = abortOnFailure;
     this.client = client;
     this.api = client.api;
-    this.startTime= new Date().getTime();
+    this.startTime = new Date().getTime();
     this.timeout = this.client.api.globals.assertWaitForConditionTimeout || 0;
     this.shouldWait = this.timeout > 0;
     this.rescheduleInterval = this.client.api.globals.waitForConditionPollInterval || 500;
@@ -57,7 +57,6 @@ module.exports = new (function() {
    * @returns {*}
    * @private
    */
-
   BaseAssertion.prototype._executeCommand = function() {
     var self = this;
     var methods = [
@@ -73,7 +72,6 @@ module.exports = new (function() {
         if (typeof self[name] !== 'function') {
           throw new Error('Assertion must implement method ' + name);
         }
-
       } else if (typeof self[method] == 'undefined') {
         throw new Error('Assertion must implement method/property ' + method);
       }
@@ -113,7 +111,7 @@ module.exports = new (function() {
       return this.message;
     }
     var timeLogged = passed? timeSpent : this.timeout;
-    return this.message +  ' after ' + timeLogged + ' milliseconds.';
+    return this.message + ' after ' + timeLogged + ' milliseconds.';
   };
 
   BaseAssertion.prototype._reschedule = function() {

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -36,9 +36,10 @@ module.exports = new (function() {
     this.client = client;
     this.api = client.api;
     this.startTime = new Date().getTime();
-    this.timeout = this.client.api.globals.assertWaitForConditionTimeout || 0;
+    this.globals = this.api.globals || {};
+    this.timeout = this.globals.assertWaitForConditionTimeout || 0; //ms
     this.shouldWait = this.timeout > 0;
-    this.rescheduleInterval = this.client.api.globals.waitForConditionPollInterval || 500;
+    this.rescheduleInterval = this.globals.waitForConditionPollInterval || 500; //ms
   }
 
   util.inherits(BaseAssertion, events.EventEmitter);

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -38,8 +38,8 @@ module.exports = new (function() {
     this.startTime = new Date().getTime();
     this.globals = this.api.globals || {};
     this.timeout = this.globals.assertWaitForConditionTimeout || 0; //ms
-    this.shouldWait = this.timeout > 0;
     this.rescheduleInterval = this.globals.waitForConditionPollInterval || 500; //ms
+    this.shouldWait = this.timeout > 0;
   }
 
   util.inherits(BaseAssertion, events.EventEmitter);

--- a/lib/core/assertion.js
+++ b/lib/core/assertion.js
@@ -73,7 +73,12 @@ module.exports = new (function() {
       }
     });
 
-    return this.command(function(result) {
+    var startTime= new Date().getTime(),
+        timeout = self.client.api.globals.assertWaitForConditionTimeout || 0,
+        rescheduleInterval = self.client.api.globals.waitForConditionPollInterval || 500,
+        shouldWait = timeout != 0;
+
+    var processResult = function(result) {
       var passed, value;
 
       if (typeof self.failure == 'function' && self.failure(result)) {
@@ -84,10 +89,22 @@ module.exports = new (function() {
         passed = self.pass(value);
       }
 
-      var expected = typeof self.expected == 'function' ? self.expected() : self.expected;
-      self.client.assertion(passed, value, expected, self.message, self.abortOnFailure);
+      var expected = typeof self.expected == 'function' ? self.expected() : self.expected,
+          timeSpent = new Date().getTime() - startTime,
+          addlMessage = shouldWait ? self.message + ' after ' + timeSpent + ' milliseconds.' : '',
+          message = self.message + addlMessage;
+
+      if (shouldWait && !passed && timeSpent < timeout) {
+        var that = self;
+        return setTimeout(function() {
+          that.command(processResult);
+        }, rescheduleInterval)
+      }
+
+      self.client.assertion(passed, value, expected, message, self.abortOnFailure);
       self.emit('complete');
-    });
+    };
+    return this.command(processResult);
   };
 
   /**
@@ -216,4 +233,3 @@ module.exports = new (function() {
     initialized = true;
   };
 })();
-

--- a/tests/src/testAssertions.js
+++ b/tests/src/testAssertions.js
@@ -1,11 +1,13 @@
+var BASE_PATH = process.env.NIGHTWATCH_COV ? 'lib-cov' : 'lib';
+var Api = require('../../' + BASE_PATH + '/core/api.js');
+
 module.exports = {
   setUp: function (callback) {
-    this.client = require('../nightwatch.js').init({}, callback);
-
     callback();
   },
 
   'Testing assertions loaded' : function(test) {
+    this.client = require('../nightwatch.js').init({});
     var assertModule = require('assert');
     var prop;
     for (prop in assertModule) {
@@ -48,6 +50,60 @@ module.exports = {
     test.ok('title' in this.client.api.verify);
 
     test.done();
+  },
+
+  'Testing passed assertion retry' : function(test) {
+    var assertionFn = require('../../' + BASE_PATH + '/api/assertions/containsText.js');
+    var client = {
+      options: {},
+      api : {
+        globals: { retryAssertionTimeout: 5 },
+        getText : function(cssSelector, callback) {
+          test.equals(cssSelector, '.test_element');
+          callback({
+            value : 'expected text result'
+          });
+        }
+      },
+      assertion : function(passed, result, expected, msg, abortOnFailure) {
+        test.equals(passed, true);
+        test.equals(result, 'expected text result');
+        test.equals(expected, 'text result');
+        test.equals(abortOnFailure, true);
+        test.equal(msg.indexOf('Test message after'), 0);
+        test.done();
+      }
+    };
+    Api.init(client);
+    var m = Api.createAssertion('containsText', assertionFn, true, client);
+    m._commandFn('.test_element', 'text result', 'Test message');
+  },
+
+  'Testing failed assertion retry' : function(test) {
+    var assertionFn = require('../../' + BASE_PATH + '/api/assertions/containsText.js');
+    var client = {
+      options: {},
+      api : {
+        globals: { retryAssertionTimeout: 5 },
+        getText : function(cssSelector, callback) {
+          test.equals(cssSelector, '.test_element');
+          callback({
+            value : 'not_expected'
+          });
+        }
+      },
+      assertion : function(passed, result, expected, msg, abortOnFailure) {
+        test.equals(passed, false);
+        test.equals(result, 'not_expected');
+        test.equals(expected, 'text result');
+        test.equals(abortOnFailure, true);
+        test.equals(msg, 'Test message after 5 milliseconds.');
+        test.done();
+      }
+    };
+    Api.init(client);
+    var m = Api.createAssertion('containsText', assertionFn, true, client);
+    m._commandFn('.test_element', 'text result', 'Test message');
   },
 
   tearDown : function(callback) {


### PR DESCRIPTION
This adds the option to add a timeout (defined in globals file) before failing in assertions. The use case here is for AJAX-heavy pages where I would like the test to wait some amount of time before the validation fails.

Currently, this can be done by creating custom assertions but this is cumbersome if you know you'll want this behavior for virtually all assertion functions (visible, containsText, elementPresent, etc).

Eventually it may make sense to add a parameter (ms) to the individual assertion functions, so the timeout can be defined in a case-by-case basis, rather than globally. But for now, I find it's a huge benefit to be able to do this on a global scale (i.e., do it for every single assertion).

The timeout gets defined in the nightwatch.json file. For example:

`assertWaitForConditionTimeout = 2000`