### PR TITLE
Fix to adaptGlobalHook

### DIFF
--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -284,7 +284,7 @@ TestSuite.prototype.adaptGlobalHook = function(hookName) {
   return this.makePromise(function(done) {
     var argsCount, expectedCount = 1;
     if (Utils.checkFunction(hookName, this.options.globals)) {
-      argsCount = this.options.globals.beforeEach.length;
+      argsCount = this.options.globals[hookName].length;
       expectedCount = argsCount == 2 ? 2 : 1;
     }
 


### PR DESCRIPTION
Fix adaptGlobalHook to get expected count from hookName, not hardcoded beforeEach.

Fixes `TypeError: Cannot read property 'length' of undefined ` which gets thrown if supplying a hook other than beforeEach.