### PR TITLE
Fix deprecation notice when passing firefox_profile to any test_settings

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -434,6 +434,7 @@ CliRunner.prototype = {
    * @returns {CliRunner}
    */
   mergeSeleniumOptions : function() {
+    var self = this;
     if (!this.manageSelenium) {
       return this;
     }
@@ -441,7 +442,7 @@ CliRunner.prototype = {
     this.mergeCliArgs();
 
     var deprecationNotice = function(propertyName, newSettingName) {
-      this.logWarning('DEPRECATION NOTICE: Property ' + propertyName + ' is deprecated since v0.5. Please' +
+      self.logWarning('DEPRECATION NOTICE: Property ' + propertyName + ' is deprecated since v0.5. Please' +
         ' use the "cli_args" object on the "selenium" property to define "' + newSettingName + '". E.g.:');
       var demoObj = '{\n' +
         '  "cli_args": {\n' +


### PR DESCRIPTION
Fix deprecation notice when passing firefox_profile to any test_settings.  Currently throws a TypeError.