### PR TITLE
Fix to use environment-specific selenium start_process setting if available

### DIFF
--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -392,9 +392,11 @@ CliRunner.prototype = {
       }
 
       this.manageSelenium = this.settings.selenium.start_process || false;
+      this.startSession = this.settings.selenium.start_session;
 
-      if (this.settings.selenium.start_session === false) {
-        this.startSession = false;
+      if (typeof this.settings.selenium.start_session == 'undefined') {
+        // defaults to true
+        this.startSession = true;
       }
     }
 

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -390,9 +390,9 @@ CliRunner.prototype = {
       for (var prop in this.test_settings.selenium) {
         this.settings.selenium[prop] = this.test_settings.selenium[prop];
       }
-      if (this.settings.selenium.start_process === false) {
-        this.manageSelenium = false;
-      }
+
+      this.manageSelenium = this.settings.selenium.start_process || false;
+
       if (this.settings.selenium.start_session === false) {
         this.startSession = false;
       }

--- a/tests/src/runner/testCliRunner.js
+++ b/tests/src/runner/testCliRunner.js
@@ -86,6 +86,21 @@ module.exports = {
         }
       }
     });
+    mockery.registerMock('./selenium_override.json', {
+      src_folders : 'tests',
+      selenium : {
+        start_process: false,
+        start_session: false
+      },
+      test_settings : {
+        'default' : {
+          selenium : {
+            start_process : true,
+            start_session : true
+          }
+        }
+      }
+    });
     mockery.registerMock('./custom.json', {
       src_folders : ['tests'],
       selenium : {
@@ -145,6 +160,9 @@ module.exports = {
         }
         if (b == './sauce.json') {
           return './sauce.json';
+        }
+        if (b == './selenium_override.json') {
+          return './selenium_override.json';
         }
         return './nightwatch.json';
       },
@@ -519,6 +537,26 @@ module.exports = {
 
     test.equal(runner.manageSelenium, false);
     test.equal(runner.startSession, false);
+    test.done();
+  },
+
+  testStartSeleniumEnvironmentOverride : function(test) {
+    mockery.registerMock('fs', {
+      existsSync : function(module) {
+        if (module == './selenium_override.json') {
+          return true;
+        }
+        return false;
+      }
+    });
+    var CliRunner = require('../../../'+ BASE_PATH +'/../lib/runner/cli/clirunner.js');
+    var runner = new CliRunner({
+      config : './selenium_override.json',
+      env : 'default'
+    }).init();
+
+    test.equal(runner.manageSelenium, true);
+    test.equal(runner.startSession, true);
     test.done();
   },
 


### PR DESCRIPTION
Currently, if your configuration specifies an environment-specific selenium start_process value that differs from the global one, it will defer to the global. I think the expected behavior is to use the test-specific one.

For example a config like:
```javascript
{ 
  "selenium" : { "start_process" : false },
  "test_settings" : {
    "default" : {
      "selenium" : { "start_process" : true }
    }
  }
}
```
Currently defaults to start_process being false - but I think it should be true.