### PR TITLE
Fix currentTest name on api

### DIFF
--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -84,7 +84,7 @@ TestSuite.prototype.initHooks = function() {
           hookFn.call(context, api, done);
         });
       };
-   })(item, argsCount);
+    })(item, argsCount);
 
     if (index > -1) {
       self.testResults.steps.splice(index, 1);
@@ -222,7 +222,7 @@ TestSuite.prototype.setCurrentTest = function() {
     name : this.currentTest,
     module : moduleKey.replace(path.sep , '/')
   });
-}
+};
 
 TestSuite.prototype.runNextTestCase = function(deffered) {
   this.currentTest = this.module.getNextKey();

--- a/lib/runner/testsuite.js
+++ b/lib/runner/testsuite.js
@@ -150,12 +150,7 @@ TestSuite.prototype.run = function() {
     }
     this.deferred.resolve(this.testResults);
   } else {
-    var moduleKey = this.getReportKey();
-    this.client.api('currentTest', {
-      name : this.currentTest,
-      module : moduleKey.replace(path.sep , '/')
-    });
-
+    this.setCurrentTest();
     this.globalBeforeEach()
       .then(function() {
         return self.runTestSuiteModule();
@@ -221,8 +216,17 @@ TestSuite.prototype.onTestCaseFinished = function(results, errors, time) {
   this.emit('testcase:finished', results, errors, time);
 };
 
+TestSuite.prototype.setCurrentTest = function() {
+  var moduleKey = this.getReportKey();
+  return this.client.api('currentTest', {
+    name : this.currentTest,
+    module : moduleKey.replace(path.sep , '/')
+  });
+}
+
 TestSuite.prototype.runNextTestCase = function(deffered) {
   this.currentTest = this.module.getNextKey();
+  this.setCurrentTest();
   var self = this;
 
   deffered = deffered || Q.defer();

--- a/tests/sampletests/before-after/sampleSingleTest.js
+++ b/tests/sampletests/before-after/sampleSingleTest.js
@@ -1,0 +1,32 @@
+module.exports = {
+  beforeEach : function(client, callback) {
+    var testName = client.currentTest.name;
+    client.globals.test.deepEqual(testName, 'demoTest');
+    callback();
+  },
+
+  before : function(client, callback) {
+    var testName = client.currentTest.name;
+    client.globals.test.deepEqual(testName, '');
+    callback();
+  },
+
+  demoTest : function (client) {
+    var testName = client.currentTest.name;
+    client.globals.test.deepEqual(testName, 'demoTest');
+    client.end();
+  },
+
+  afterEach : function(callback) {
+    var client = this.client;
+    var testName = client.currentTest.name;
+    client.globals.test.deepEqual(testName, 'demoTest');
+    callback();
+  },
+
+  after : function(client, callback) {
+    var testName = client.currentTest.name;
+    client.globals.test.deepEqual(testName, null);
+    callback();
+  }
+};

--- a/tests/sampletests/before-after/syncBeforeAndAfter.js
+++ b/tests/sampletests/before-after/syncBeforeAndAfter.js
@@ -9,9 +9,13 @@ module.exports = {
 
   demoTestSyncOne : function (client) {
     client.url('http://localhost');
+    var testName = client.currentTest.name;
+    client.globals.test.deepEqual(testName, 'demoTestSyncOne');
   },
 
   demoTestSyncTwo : function (client) {
+    var testName = client.currentTest.name;
+    client.globals.test.deepEqual(testName, 'demoTestSyncTwo');
     client.end();
   },
 

--- a/tests/src/runner/testRunner.js
+++ b/tests/src/runner/testRunner.js
@@ -163,7 +163,7 @@ module.exports = {
   },
 
   testRunAsyncWithBeforeAndAfter : function(test) {
-    test.expect(27);
+    test.expect(34);
     var testsPath = path.join(process.cwd(), '/sampletests/before-after');
     this.Runner.run([testsPath], {
       seleniumPort : 10195,
@@ -198,7 +198,7 @@ module.exports = {
   },
 
   testRunWithGlobalBeforeAndAfter : function(test) {
-    test.expect(15);
+    test.expect(22);
     var testsPath = path.join(process.cwd(), '/sampletests/before-after');
     var beforeEachCount = 0;
     var afterEachCount = 0;
@@ -216,14 +216,14 @@ module.exports = {
       start_session : true
     }, function(err, results) {
       test.equals(err, null);
-      test.equals(beforeEachCount, 2);
-      test.equals(afterEachCount, 2);
+      test.equals(beforeEachCount, 3);
+      test.equals(afterEachCount, 3);
       test.done();
     });
   },
 
   testRunWithGlobalAsyncBeforeEachAndAfterEach : function(test) {
-    test.expect(15);
+    test.expect(22);
     var testsPath = path.join(process.cwd(), '/sampletests/before-after');
     var beforeEachCount = 0;
     var afterEachCount = 0;
@@ -245,14 +245,14 @@ module.exports = {
       start_session : true
     }, function(err, results) {
       test.equals(err, null);
-      test.equals(beforeEachCount, 2);
-      test.equals(afterEachCount, 2);
+      test.equals(beforeEachCount, 3);
+      test.equals(afterEachCount, 3);
       test.done();
     });
   },
 
   testRunWithGlobalAsyncBeforeEachAndAfterEachWithBrowser : function(test) {
-    test.expect(17);
+    test.expect(25);
     var testsPath = path.join(process.cwd(), '/sampletests/before-after');
     var beforeEachCount = 0;
     var afterEachCount = 0;
@@ -281,14 +281,14 @@ module.exports = {
       start_session : true
     }, function(err, results) {
       test.equals(err, null);
-      test.equals(beforeEachCount, 2);
-      test.equals(afterEachCount, 2);
+      test.equals(beforeEachCount, 3);
+      test.equals(afterEachCount, 3);
       test.done();
     });
   },
 
   testRunWithGlobalReporter : function(test) {
-    test.expect(15);
+    test.expect(22);
     var testsPath = path.join(process.cwd(), '/sampletests/before-after');
     var reporterCount = 0;
     this.Runner.run([testsPath], {
@@ -313,7 +313,7 @@ module.exports = {
   },
 
   testRunWithGlobalAsyncReporter : function(test) {
-    test.expect(15);
+    test.expect(22);
     var testsPath = path.join(process.cwd(), '/sampletests/before-after');
     var reporterCount = 0;
     this.Runner.run([testsPath], {
@@ -491,6 +491,32 @@ module.exports = {
 
       test.done();
     });
-  }
+  },
 
+  testRunCurrentTestName : function(test) {
+    test.expect(8);
+    var testsPath = path.join(process.cwd(), '/sampletests/before-after/sampleSingleTest.js');
+    this.Runner.run([testsPath], {
+      seleniumPort : 10195,
+      silent : true,
+      output : false,
+      globals : {
+        test : test,
+        beforeEach: function(client, done) {
+          test.deepEqual(client.currentTest.name, '');
+          done();
+        },
+        afterEach: function(client, done) {
+          test.deepEqual(client.currentTest.name, null);
+          done();
+        }
+      }
+    }, {
+      output_folder : false,
+      start_session : true
+    }, function(err, results) {
+      test.equals(err, null);
+      test.done();
+    });
+  }
 };


### PR DESCRIPTION
Currently client.api.currentTest.name is set to empty string. This fix sets it for each test before running beforeEach.