### PR TITLE
Added click functionality exposed through Selenium

### DIFF
--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -448,7 +448,7 @@ module.exports = function(Nightwatch) {
    * @api protocol
    */
   Actions.mouseButtonClick = function(button, callback) {
-
+    var buttonIndex;
     if (typeof button === 'string') {
       buttonIndex = [
         MOUSE_BUTTON_LEFT,

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -442,6 +442,8 @@ module.exports = function(Nightwatch) {
   /**
    * Click at the current mouse coordinates (set by moveto).
    *
+   * The button can be (0, 1, 2) or ('left', 'middle', 'right'). It defaults to left mouse button, and if you don't pass in a button but do pass in a callback, it will handle it correctly.
+   *
    * @link /session/:sessionId/click
    * @param {string|number} button The mouse button
    * @param {function} [callback] Optional callback function to be called when the command finishes.

--- a/lib/api/protocol.js
+++ b/lib/api/protocol.js
@@ -440,6 +440,31 @@ module.exports = function(Nightwatch) {
   };
 
   /**
+   * Click at the current mouse coordinates (set by moveto).
+   *
+   * @link /session/:sessionId/click
+   * @param {string|number} button The mouse button
+   * @param {function} [callback] Optional callback function to be called when the command finishes.
+   * @api protocol
+   */
+  Actions.mouseButtonClick = function(button, callback) {
+
+    if (typeof button === 'string') {
+      buttonIndex = [
+        MOUSE_BUTTON_LEFT,
+        MOUSE_BUTTON_MIDDLE,
+        MOUSE_BUTTON_RIGHT
+      ].indexOf(button.toLowerCase());
+
+      if (buttonIndex !== -1) {
+        button = buttonIndex;
+      }
+    }
+
+    return postRequest('/click', {button: button}, callback);
+  };
+
+  /**
    * Click and hold the left mouse button (at the coordinates set by the last moveto command). Note that the next mouse-related command that should follow is `mouseButtonUp` . Any other mouse command (such as click or another call to buttondown) will yield undefined behaviour.
    *
    * Can be used for implementing drag-and-drop. The button can be (0, 1, 2) or ('left', 'middle', 'right'). It defaults to left mouse button, and if you don't pass in a button but do pass in a callback, it will handle it correctly.

--- a/tests/src/testProtocolActions.js
+++ b/tests/src/testProtocolActions.js
@@ -380,6 +380,34 @@ module.exports = {
     });
   },
 
+  'test mouseButtonClick click left' : function(test) {
+    var client = this.client;
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function(sessionId) {
+      var command = protocol.mouseButtonClick('left', function callback() {
+        test.done();
+      });
+
+      test.equal(command.request.method, 'POST');
+      test.equal(command.data, '{"button":0}');
+      test.equal(command.request.path, '/wd/hub/session/1352110219202/click');
+    });
+  },
+
+  'test mouseButtonClick click right' : function(test) {
+    var client = this.client;
+    var protocol = this.protocol;
+
+    this.client.on('selenium:session_create', function(sessionId) {
+      var command = protocol.mouseButtonClick('right', function callback() {
+        test.done();
+      });
+
+      test.equal(command.data, '{"button":2}');
+    });
+  },
+
   'test mouseButtonDown click left' : function(test) {
     var client = this.client;
     var protocol = this.protocol;


### PR DESCRIPTION
The click method is necessary to simulate the real click (left/middle/rifgt button) event on browers .
It's useful for open a context menu with the right button for eg.

It's the only way, because if you execute a mouseButtonDown('right') and then a mouseButtonUp('right') on a link that triggers a wrong mouse event and it's open the link... (cf. http://stackoverflow.com/questions/29011483/right-click-with-nightwatch/29751560)
