### PR TITLE
Update urlEquals.js

### DIFF
--- a/lib/api/assertions/urlEquals.js
+++ b/lib/api/assertions/urlEquals.js
@@ -19,6 +19,9 @@ exports.assertion = function(expected, msg) {
   this.message = msg || util.format('Testing if the URL equals "%s".', expected);
   this.expected = expected;
 
+  //custom code
+  if (typeof expected === "function") this.expected = expected();
+
   this.pass = function(value) {
     return value === this.expected;
   };


### PR DESCRIPTION
I added the validation to assert.urlEquals to check if we pass a function name we need to get the return value.
this also addresses the issue #452 I've opened.